### PR TITLE
enable `init` in docker to avoid leaving tons of zombie processes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,5 +14,5 @@ services:
     restart: unless-stopped
     # volumes:
     #   - ./:/data        # if you want to read homeassistant.db, homeassistant.db is in the container at /data/
-    command: python3 main.py 
-
+    command: python3 main.py
+    init: true


### PR DESCRIPTION
It appears that chromedriver and chrome_crashpad_handler may be left as zombie process and never get recycled.
```
root      632392  0.0  0.0      0     0 ?        Z    Jan10   0:05 [chromedriver] <defunct>
root      632408  0.0  0.0      0     0 ?        Z    Jan10   0:00 [chrome_crashpad] <defunct>
root      632410  0.0  0.0      0     0 ?        Z    Jan10   0:00 [chrome_crashpad] <defunct>
root      688086  0.0  0.0      0     0 ?        Z    Jan11   0:05 [chromedriver] <defunct>
root      688102  0.0  0.0      0     0 ?        Z    Jan11   0:00 [chrome_crashpad] <defunct>
root      688104  0.0  0.0      0     0 ?        Z    Jan11   0:00 [chrome_crashpad] <defunct>
root      752364  0.0  0.0      0     0 ?        Z    Jan11   0:05 [chromedriver] <defunct>
root      752380  0.0  0.0      0     0 ?        Z    Jan11   0:00 [chrome_crashpad] <defunct>
root      752382  0.0  0.0      0     0 ?        Z    Jan11   0:00 [chrome_crashpad] <defunct>
root      820175  0.0  0.0      0     0 ?        Z    Jan12   0:05 [chromedriver] <defunct>
root      820191  0.0  0.0      0     0 ?        Z    Jan12   0:00 [chrome_crashpad] <defunct>
root      820193  0.0  0.0      0     0 ?        Z    Jan12   0:00 [chrome_crashpad] <defunct>
root      884612  0.0  0.0      0     0 ?        Z    Jan12   0:05 [chromedriver] <defunct>
root      884629  0.0  0.0      0     0 ?        Z    Jan12   0:00 [chrome_crashpad] <defunct>
root      884631  0.0  0.0      0     0 ?        Z    Jan12   0:00 [chrome_crashpad] <defunct>
root      984200  0.0  0.0      0     0 ?        Z    Jan13   0:03 [chromedriver] <defunct>
root      984220  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      984222  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      984506  0.0  0.0      0     0 ?        Z    Jan13   0:02 [chromedriver] <defunct>
root      984522  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      984524  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      984855  0.0  0.0      0     0 ?        Z    Jan13   0:03 [chromedriver] <defunct>
root      984869  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      984871  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      985136  0.0  0.0      0     0 ?        Z    Jan13   0:02 [chromedriver] <defunct>
root      985151  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      985153  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      985345  0.0  0.0      0     0 ?        Z    Jan13   0:02 [chromedriver] <defunct>
root      985361  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      985363  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      992544  0.0  0.0      0     0 ?        Z    Jan13   0:02 [chromedriver] <defunct>
root      992560  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      992562  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      992885  0.0  0.0      0     0 ?        Z    Jan13   0:02 [chromedriver] <defunct>
root      992900  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      992902  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      993184  0.0  0.0      0     0 ?        Z    Jan13   0:02 [chromedriver] <defunct>
root      993199  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      993201  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      993459  0.0  0.0      0     0 ?        Z    Jan13   0:02 [chromedriver] <defunct>
root      993473  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      993475  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      993653  0.0  0.0      0     0 ?        Z    Jan13   0:02 [chromedriver] <defunct>
root      993669  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
root      993671  0.0  0.0      0     0 ?        Z    Jan13   0:00 [chrome_crashpad] <defunct>
```

Enable `init` in the container to help reap those zombie processes.