### PR TITLE
Update sensor_updator.py

### DIFF
--- a/scripts/sensor_updator.py
+++ b/scripts/sensor_updator.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime
+from datetime import datetime,timedelta
 
 import requests
 from sympy import true
@@ -76,12 +76,10 @@ class SensorUpdator:
             if usage
             else MONTH_CHARGE_SENSOR_NAME + postfix
         )
-        if datetime.now().month == 1:
-            last_year = datetime.now().year -1 
-            last_reset = datetime.now().replace(year=last_year, month=12).strftime("%Y-%m")
-        else:
-            last_updated = datetime.now().month - 1
-            last_reset = datetime.now().replace(month=last_updated).strftime("%Y-%m")
+        current_date = datetime.now()
+        first_day_of_current_month = current_date.replace(day=1)
+        last_day_of_previous_month = first_day_of_current_month - timedelta(days=1)
+        last_reset = last_day_of_previous_month.strftime("%Y-%m")
         request_body = {
             "state": sensorState,
             "unique_id": sensorName,


### PR DESCRIPTION
修改了update_month_data函数中关于月份计算的逻辑，原逻辑在执行日期（例如2025年3月30日）大于上月最大日期（2025年2月28日）时会产生day is out of range for month报错。原因是.replace重置月份后日期（保持30日）不会变化从而导致溢出（例子中2月份day最大为28）。修改后的逻辑利用当月第一天减去一天自动处理跨年跨越问题。