### PR TITLE
fix: suppress ONNX Runtime thread affinity warning in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ RECHARGE_NOTIFY=Flase
 BALANCE=5.0
 # pushplus token 如果有多个就用","分隔，","之间不要有空格，单个就不要有","
 PUSHPLUS_TOKEN=xxxxxxx,xxxxxxx,xxxxxxx
+
+## ONNX Runtime 线程数限制（可选）
+# 在 Docker 中限制了 CPU 数量时，设置此项可消除线程亲和度错误
+# 建议设置为 Docker 分配的 CPU 核心数
+# OP_NUM_THREADS=2
 ```
 
 4. 运行

--- a/example.env
+++ b/example.env
@@ -37,3 +37,8 @@ RECHARGE_NOTIFY=False
 BALANCE=5.0
 # pushplus token 如果有多个就用","分隔，","之间不要有空格
 PUSHPLUS_TOKEN=xxxxxxx,xxxxxxx,xxxxxxx
+
+## ONNX Runtime 线程数限制（可选）
+# 在 Docker 中限制了 CPU 数量时，设置此项可消除线程亲和度错误
+# 建议设置为 Docker 分配的 CPU 核心数
+# OP_NUM_THREADS=2

--- a/scripts/onnx.py
+++ b/scripts/onnx.py
@@ -2,6 +2,7 @@
 from PIL import ImageDraw,Image,ImageOps
 import numpy as np
 import onnxruntime
+import os
 
 anchors = [[(116,90),(156,198),(373,326)],[(30,61),(62,45),(59,119)],[(10,13),(16,30),(33,23)]]
 anchors_yolo_tiny = [[(81, 82), (135, 169), (344, 319)], [(10, 14), (23, 27), (37, 58)]]
@@ -11,7 +12,15 @@ CLASSES=["target"]
 
 class ONNX:
     def __init__(self,onnx_file_name="captcha.onnx"):
-        self.onnx_session = onnxruntime.InferenceSession(onnx_file_name) 
+        options = onnxruntime.SessionOptions()
+        thread_limit = os.getenv("OP_NUM_THREADS")
+
+        if thread_limit and thread_limit.isdigit():
+            limit = int(thread_limit)
+            options.intra_op_num_threads = limit
+            options.inter_op_num_threads = limit
+
+        self.onnx_session = onnxruntime.InferenceSession(onnx_file_name, sess_options=options)
 
     # sigmoid函数
     def sigmoid(self,x):


### PR DESCRIPTION
## Problem

When running in a Docker container with CPU affinity or count restrictions,
ONNX Runtime emits the following error:

```
[E:onnxruntime:Default, env.cc:228 ThreadMain] pthread_setaffinity_np failed
for thread: 17, index: 6, mask: {7, }, error code: 22 error msg: Invalid
argument. Specify the number of threads explicitly so the affinity is not set.
```

ONNX Runtime automatically detects the full CPU topology of the host and attempts to set thread affinity accordingly. 
However, when Docker restricts the container to a subset of CPU cores via `--cpuset-cpus` (e.g., to pin the workload to efficiency cores / little cores on a hybrid CPU/SOC), the core indices visible inside the container no longer match the host topology, causing `pthread_setaffinity_np` to fail with `Invalid argument`.

This is commonly triggered by Docker CPU restrictions such as:

```bash
# Limit to specific CPU cores (e.g., cores 0 and 1 only)
docker run --cpuset-cpus="0-1" ...=
```

Or in docker-compose.yml:

```
services:
  app:
    cpuset: "0-1"
    deploy:
      resources:
        limits:
          cpus: "2"
```

## Solution

Explicitly setting `intra_op_num_threads` and `inter_op_num_threads` via
`SessionOptions` causes ONNX Runtime to skip thread affinity assignment,
eliminating the error.

A new optional environment variable `OP_NUM_THREADS` is introduced. Set it to
the number of CPU cores allocated to the Docker container. When unset, behavior
is identical to before.
