### PR TITLE
feat: make LLM endpoint configurable for multi-provider support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,9 @@ options:
   RECHARGE_NOTIFY: false
   BALANCE: 5.0
   PUSHPLUS_TOKEN: "xxxx,xxxx"
+  LLM_API_KEY: ""
+  LLM_BASE_URL: ""
+  LLM_MODEL: ""
 schema:
   PHONE_NUMBER: str
   PASSWORD: password
@@ -45,3 +48,6 @@ schema:
   RECHARGE_NOTIFY: bool 
   BALANCE: float 
   PUSHPLUS_TOKEN: str
+  LLM_API_KEY: password
+  LLM_BASE_URL: str?
+  LLM_MODEL: str?

--- a/example.env
+++ b/example.env
@@ -76,9 +76,13 @@ QR_CODE_LOGIN_WAIT_TIME_INTERVAL_UNIT=10
 # OP_NUM_THREADS=2
 
 ## 大模型验证码识别配置（必填）
-# 火山引擎 ARK API Key，用于调用豆包大模型解算腾讯验证码（点击+滑块）
-# 获取地址：https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey
-ARK_API_KEY="your-ark-api-key-here"
+# API Key，用于调用大模型解算腾讯验证码（点击+滑块）
+# 支持任意 OpenAI 兼容 API（火山引擎、Google Gemini、OpenAI 等）
+LLM_API_KEY="your-api-key-here"
+# API 地址，默认火山引擎；Gemini 示例：https://generativelanguage.googleapis.com/v1beta/openai
+LLM_BASE_URL="https://ark.cn-beijing.volces.com/api/v3"
+# 模型名称，默认豆包；Gemini 示例：gemini-2.5-flash
+LLM_MODEL="doubao-seed-2-0-pro-260215"
 
 ## 调试模式（可选）
 # 设置为 true 启用短信验证码登录模式（需要人工在控制台输入短信验证码）

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ schedule==1.2.1
 Pillow==10.1.0
 numpy==1.26.2
 mysql-connector-python==9.4.0
-openai==1.58.0
+openai>=1.0.0
 # python-dotenv
 # python-dateutil

--- a/scripts/captcha_selenium.py
+++ b/scripts/captcha_selenium.py
@@ -241,10 +241,10 @@ def _solve_slider(driver: WebDriver, selectors: dict) -> bool:
         import base64
         from openai import OpenAI
 
-        api_key = __import__('os').getenv('ARK_API_KEY', '')
+        import const
         client = OpenAI(
-            base_url="https://ark.cn-beijing.volces.com/api/v3",
-            api_key=api_key
+            base_url=const.LLM_BASE_URL,
+            api_key=const.LLM_API_KEY
         )
 
         if bg_url.startswith("http"):
@@ -261,7 +261,7 @@ def _solve_slider(driver: WebDriver, selectors: dict) -> bool:
         bg_w, bg_h = img.size
 
         response = client.chat.completions.create(
-            model="doubao-seed-2-0-pro-260215",
+            model=const.LLM_MODEL,
             messages=[{
                 "role": "user",
                 "content": [

--- a/scripts/click_captcha_solver.py
+++ b/scripts/click_captcha_solver.py
@@ -11,6 +11,7 @@
 
 import base64
 import io
+import json
 import logging
 import os
 import re
@@ -118,24 +119,13 @@ class ClickCaptchaSolver:
 
     def _find_all_icons(self, icon_uris: List[str], main_uri: str,
                         main_width: int, main_height: int) -> List[Tuple[int, int]]:
-        """单次API调用，带链式思考提示，让LLM找到所有3个图标。"""
+        """单次API调用，让LLM找到所有3个图标。"""
         prompt = (
-            "你的任务是找图：3个参考图标分别在网格大图中的位置。\n\n"
-            "## 第一步：观察参考图标\n"
-            "仔细看3个参考图标，在脑中记住每个图标的：形状轮廓、主要颜色、内部细节、旋转方向。\n"
-            "注意3个图标是不同的，它们的颜色和/或形状一定有区别。\n\n"
-            "## 第二步：扫描大图网格\n"
-            f"大图（{main_width}×{main_height}像素）是一个图标网格（约4×4或3×3排列）。\n"
-            "逐行逐列扫描每个网格中的图标，找到与3个参考图标匹配的。\n\n"
-            "## 匹配规则\n"
-            "- 匹配图标与参考图标的形状和颜色必须一致（允许旋转，但旋转角度不影响匹配）\n"
-            "- 网格中可能有多个颜色相同的图标，但形状细节不同——请仔细辨别\n"
-            "- 空心/实心、线条粗细、是否有圆点等细节是关键区分点\n"
-            "- 3个目标图标在网格中的位置各不相同\n\n"
-            "## 输出\n"
-            "先简要说明每个参考图标的特征和匹配位置，然后输出一行坐标：\n"
-            "(x1, y1), (x2, y2), (x3, y3)\n"
-            "其中x、y为图标中心的比例坐标（0~1），分别对应图标A、B、C。"
+            f"大图（{main_width}×{main_height}像素）是一个图标网格。\n"
+            "找到3个参考图标(A, B, C)各自在大图网格中的位置。\n"
+            "匹配规则：形状和颜色必须一致，空心/实心、线条粗细是关键区分点，允许旋转。\n\n"
+            '输出JSON：{"coords":[[xA,yA],[xB,yB],[xC,yC]]}\n'
+            "其中x、y为图标中心的比例坐标（0~1）。"
         )
 
         content = []
@@ -150,8 +140,12 @@ class ClickCaptchaSolver:
         try:
             response = self.client.chat.completions.create(
                 model=self.model,
-                messages=[{"role": "user", "content": content}],
-                max_tokens=500,
+                messages=[
+                    {"role": "system", "content": "Output valid JSON only. No markdown, no explanation."},
+                    {"role": "user", "content": content},
+                ],
+                max_tokens=4096,
+                response_format={"type": "json_object"},
             )
             output = response.choices[0].message.content or ""
             logger.info(f"大模型响应: {output[:400]}")
@@ -162,7 +156,24 @@ class ClickCaptchaSolver:
 
     def _parse_coordinates(self, text: str,
                            main_width: int, main_height: int) -> List[Tuple[int, int]]:
-        """从LLM返回文本中解析坐标并转为像素。"""
+        """从LLM返回文本中提取JSON坐标并转为像素。"""
+        # 优先尝试JSON解析
+        match = re.search(r'\{.*"coords"\s*:\s*\[.*?\]\s*\}', text, re.DOTALL)
+        if match:
+            try:
+                data = json.loads(match.group())
+                result = []
+                for x, y in data["coords"]:
+                    x, y = float(x), float(y)
+                    if max(x, y) <= 1.5:
+                        result.append((round(x * main_width), round(y * main_height)))
+                    else:
+                        result.append((round(x), round(y)))
+                return result
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+                pass
+
+        # 回退：正则解析
         coords = []
         paren_pairs = re.findall(r'\(\s*(\d+\.?\d*)\s*[,，]\s*(\d+\.?\d*)\s*\)', text)
         for x_str, y_str in paren_pairs:

--- a/scripts/click_captcha_solver.py
+++ b/scripts/click_captcha_solver.py
@@ -20,6 +20,8 @@ import requests
 from PIL import Image
 from openai import OpenAI
 
+import const
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,16 +32,16 @@ class ClickCaptchaSolver:
                  api_key: Optional[str] = None,
                  model: Optional[str] = None,
                  base_url: Optional[str] = None):
-        self.api_key = (api_key or os.getenv('ARK_API_KEY', '').strip())
-        self.model = model or "doubao-seed-2-0-pro-260215"
-        self.base_url = base_url or "https://ark.cn-beijing.volces.com/api/v3"
+        self.api_key = api_key or const.LLM_API_KEY
+        self.model = model or const.LLM_MODEL
+        self.base_url = base_url or const.LLM_BASE_URL
         self._client: Optional[OpenAI] = None
 
     @property
     def client(self) -> OpenAI:
         if self._client is None:
             if not self.api_key:
-                raise RuntimeError("ARK_API_KEY 未设置，验证码解算将失败")
+                raise RuntimeError("LLM_API_KEY 未设置，验证码解算将失败")
             self._client = OpenAI(base_url=self.base_url, api_key=self.api_key)
         return self._client
 

--- a/scripts/const.py
+++ b/scripts/const.py
@@ -28,6 +28,10 @@ PREPAY_BALANCE_SENSOR_NAME = "sensor.prepay_balance"
 BALANCE_UNIT = "CNY"
 USAGE_UNIT = "KWH"
 
+LLM_API_KEY = os.getenv('LLM_API_KEY', '').strip()
+LLM_BASE_URL = os.getenv('LLM_BASE_URL', 'https://ark.cn-beijing.volces.com/api/v3')
+LLM_MODEL = os.getenv('LLM_MODEL', 'doubao-seed-2-0-pro-260215')
+
 
 def get_data_dir() -> str:
     """获取数据存储目录：Docker 用 /data，本地用项目下的 data/"""

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -24,6 +24,10 @@ def main():
         try:
             for key, value in options.items():
                 os.environ[key] = str(value)
+            import const
+            const.LLM_API_KEY = os.getenv('LLM_API_KEY', '').strip()
+            const.LLM_BASE_URL = os.getenv('LLM_BASE_URL', 'https://ark.cn-beijing.volces.com/api/v3')
+            const.LLM_MODEL = os.getenv('LLM_MODEL', 'doubao-seed-2-0-pro-260215')
             logging.info(f"当前以Homeassistant Add-on 形式运行.")
         except Exception as e:
             logging.error(f"读取 options.json 文件失败，程序将退出，错误信息: {e}。")


### PR DESCRIPTION
## Summary
- LLM API endpoint (key, base URL, model) now configurable via `LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL` environment variables, no longer hardcoded to 火山引擎
- Click captcha solver prompt simplified + JSON output format (`response_format`) for cross-provider compatibility (tested with Gemini, should work with any OpenAI-compatible API)
- Added corresponding HA addon config options in `config.yaml`

## Changes
- `scripts/const.py`: centralized `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL` from env vars (defaults to 火山引擎 for backward compatibility)
- `scripts/main.py`: reload LLM config after HA addon options load
- `scripts/captcha_selenium.py` + `scripts/click_captcha_solver.py`: use `const.LLM_*` instead of hardcoded values; add `response_format: {"type": "json_object"}` and system message for reliable structured output
- `config.yaml` + `example.env`: document new config options with examples (Gemini, OpenAI, etc.)
- `requirements.txt`: relax `openai` version pin to `>=1.0.0`

## Note
`--headless=new` mode causes Tencent captcha to exclusively serve slider-type CAPTCHAs. The current `_solve_slider` implementation silently fails in this scenario (no log output, no error). Click-type captcha works correctly with this PR. Consider restoring `xvfb` virtual display to avoid headless detection by the CAPTCHA system.