### PR TITLE
fix: strip quotes from JOB_START_TIME env var to fix strptime parse error

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -40,7 +40,7 @@ def main():
         logging.info(f"读取环境变量 PHONE_NUMBER : {PHONE_NUMBER}")
         PASSWORD = os.getenv("PASSWORD")
         HASS_URL = os.getenv("HASS_URL")
-        JOB_START_TIME = os.getenv("JOB_START_TIME","07:00" )
+        JOB_START_TIME = os.getenv("JOB_START_TIME","07:00" ).strip('"').strip("'")
         LOG_LEVEL = os.getenv("LOG_LEVEL","INFO")
         VERSION = os.getenv("VERSION")
         RETRY_TIMES_LIMIT = int(os.getenv("RETRY_TIMES_LIMIT", 5))


### PR DESCRIPTION
## 问题
Docker 运行时 JOB_START_TIME 解析报错：
```
ValueError: time data '"07:00"' does not match format '%H:%M'
```

## 原因
`.env` 中 `JOB_START_TIME="07:00"` 带双引号，docker-compose 的 `env_file` 不会自动去除引号，导致 `os.getenv()` 读到带引号的字符串值。

## 修复
在 `scripts/main.py` 第 43 行，读取 `JOB_START_TIME` 后添加 `.strip('"').strip("'")` 去除可能存在的引号。
