### PR TITLE
fix: 修复图形验证码登录异常时无法触发重试流程的问题

### DIFF
--- a/scripts/data_fetcher.py
+++ b/scripts/data_fetcher.py
@@ -930,7 +930,7 @@ class DataFetcher:
             self._browser, self._context, self._page = self._setup_browser()
         except Exception as e:
             logging.error(f"浏览器启动/连接失败: {e}")
-            return
+            raise
         ErrorWatcher.instance().set_page(self._page)
         self._random_delay(1, 3)
         updator = SensorUpdator()
@@ -956,7 +956,7 @@ class DataFetcher:
                 self._browser.close()
                 if getattr(self, '_pw', None):
                     self._pw.stop()
-                return
+                raise
             logging.info("Logged in")
             # 登录成功后保存 Cookie
             # self._save_cookies(self._page)


### PR DESCRIPTION
将 data_fetcher.py fetch() 方法中两处 return 改为 raise,
使浏览器启动失败和登录失败的异常能正确传播到 main.py 的 run_task(),
从而触发自动重试流程。